### PR TITLE
Add full text search with pg_search gem. Close #2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'coderay'
 gem 'coffee-rails', '~> 4.2'
 gem 'devise'
 gem 'pg', '~> 0.18'
+gem 'pg_search'
 gem 'puma', '~> 3.7'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'
@@ -43,7 +44,7 @@ end
 
 group :development, :test do
   gem 'pry'
-  gem 'ffaker'
+  gem 'faker'
   gem 'awesome_print'
   gem 'rspec-rails', '~> 3.6'
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,8 @@ GEM
     factory_bot_rails (5.0.1)
       factory_bot (~> 5.0.0)
       railties (>= 4.2.0)
-    ffaker (2.10.0)
+    faker (1.9.3)
+      i18n (>= 0.7)
     ffi (1.10.0)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -144,6 +145,9 @@ GEM
       shellany (~> 0.0)
     orm_adapter (0.5.0)
     pg (0.21.0)
+    pg_search (2.1.4)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -275,7 +279,7 @@ DEPENDENCIES
   database_cleaner
   devise
   factory_bot_rails
-  ffaker
+  faker
   guard-rspec
   jbuilder (~> 2.5)
   jquery-rails
@@ -284,6 +288,7 @@ DEPENDENCIES
   letter_opener
   listen (>= 3.0.5, < 3.2)
   pg (~> 0.18)
+  pg_search
   pry
   puma (~> 3.7)
   rails (~> 5.2.2)

--- a/app/controllers/til_logs_controller.rb
+++ b/app/controllers/til_logs_controller.rb
@@ -11,7 +11,7 @@ class TilLogsController < ApplicationController
       @til_logs = @til_logs.tagged_with(params[:tag])
     end
     if params[:search]
-      # do stuff
+      @til_logs = @til_logs.search_for(params[:search])
     end
   end
 

--- a/app/helpers/til_logs_helper.rb
+++ b/app/helpers/til_logs_helper.rb
@@ -25,4 +25,14 @@ module TilLogsHelper
       link_to tag, til_logs_path(tag: tag)
     end.join(', ').html_safe
   end
+
+  def index_filter_text
+    search = params[:search]
+    tag = params[:tag]
+    if search
+      "matching query '#{search}'"
+    elsif tag
+      "tagged with '#{tag}'"
+    end
+  end
 end

--- a/app/models/til_log.rb
+++ b/app/models/til_log.rb
@@ -1,5 +1,11 @@
 class TilLog < ApplicationRecord
+  include PgSearch
   acts_as_taggable
+  pg_search_scope :search_for,
+                   against: %i(title body),
+                    using: {
+                     tsearch: { prefix: true }
+                    }
 
   belongs_to :user
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,6 +13,10 @@
         <%= link_to current_user.email, edit_user_registration_path, class: 'nav-item nav-link' %>
         <%= link_to 'Sign out', destroy_user_session_path, method: :delete, class: 'nav-item nav-link' %>
         <%= link_to 'TIL Logs', til_logs_path, class: 'nav-item nav-link' %>
+        <%= form_tag(til_logs_path, method: :get, class: 'form-inline my-2 my-lg-0') do %>
+          <%= text_field_tag 'search', nil, placeholder: 'Search TilLogs...', class: "form-control mr-sm-2" %>
+          <%= submit_tag 'Search', class: "btn btn-outline-primary my-2 my-sm-0" %>
+        <% end %>
       <% else %>
         <%= link_to 'Sign in', new_user_session_path, class: 'nav-item nav-link' %>
       <% end %>

--- a/app/views/til_logs/index.html.erb
+++ b/app/views/til_logs/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Til Logs <%= "tagged with '#{params[:tag]}'" if params[:tag] %></h1>
+<h1>TIl Logs <%= index_filter_text %></h1>
 
 
 <div class='container'>
@@ -23,5 +23,9 @@
 </div>
 
 <br>
+
+<% if params[:search] || params[:tag] %>
+  <%= link_to 'All Til Logs', til_logs_path %><br/>
+<% end %>
 
 <%= link_to 'New Til Log', new_til_log_path %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user do
-
+    email {Faker::Internet.email}
+    password {SecureRandom.hex(10)}
   end
 end

--- a/spec/models/til_log_spec.rb
+++ b/spec/models/til_log_spec.rb
@@ -1,5 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe TilLog, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:til_log) { build(:til_log, user: user) }
+
+  it 'has a valid factory' do
+    expect(til_log).to be_valid
+  end
+
+  it { is_expected.to belong_to(:user) }
+
+  context 'pg_search #search_for' do
+    let!(:til_log1) { create(:til_log, user: user, title: 'tacos', body: 'foo') }
+    let!(:til_log2) { create(:til_log, user: user, title: 'foo', body: 'bar') }
+
+    it 'returns matching search in title' do
+      expect(TilLog.search_for('tacos')).to contain_exactly(til_log1)
+    end
+
+    it 'returns matching search in title and body' do
+      expect(TilLog.search_for('foo')).to contain_exactly(til_log1, til_log2)
+    end
+
+    it 'returns matches on partial match' do
+      expect(TilLog.search_for('tac')).to contain_exactly(til_log1)
+    end
+  end
 end


### PR DESCRIPTION
Allows user to search til_logs by title and body.

![til-log-search](https://user-images.githubusercontent.com/7945260/55489331-5b62de80-55f7-11e9-8d4c-ee063fe04fbd.gif)
